### PR TITLE
Pin PyMEOS 1.3 in per-folder requirements files

### DIFF
--- a/MovingPandas/requirements.txt
+++ b/MovingPandas/requirements.txt
@@ -1,0 +1,9 @@
+pymeos>=1.3.0a1
+pandas>=2.0
+matplotlib>=3.7
+geopandas>=0.13
+shapely>=2.0
+movingpandas>=0.16
+holoviews>=1.18
+distinctipy>=1.3
+tqdm>=4.65

--- a/PyMEOS_Examples/requirements.txt
+++ b/PyMEOS_Examples/requirements.txt
@@ -1,0 +1,5 @@
+pymeos>=1.3.0a1
+pandas>=2.0
+matplotlib>=3.7
+tqdm>=4.65
+contextily>=1.3


### PR DESCRIPTION
Each example folder now ships a requirements.txt that pins pymeos at or above the 1.3.0a1 alpha so users installing fresh do not pull 1.2.x and hit the unified spatial nomenclature mismatch. The notebook imports themselves (TGeogPointInst, TFloatInst, TGeomPointSeq, TGeomPointInst, STBox, pymeos_initialize) still resolve unchanged against PyMEOS 1.3 because the class layer was kept stable across the MEOS C-level rename.