### PR TITLE
Bump PyMEOS to 1.4 in per-folder requirements

### DIFF
--- a/MovingPandas/requirements.txt
+++ b/MovingPandas/requirements.txt
@@ -1,4 +1,4 @@
-pymeos>=1.3.0a1
+pymeos>=1.4.0a1
 pandas>=2.0
 matplotlib>=3.7
 geopandas>=0.13

--- a/MovingPandas/requirements.txt
+++ b/MovingPandas/requirements.txt
@@ -1,0 +1,9 @@
+pymeos>=1.3.0a1
+pandas>=2.0
+matplotlib>=3.7
+geopandas>=0.13
+shapely>=2.0
+movingpandas>=0.16
+holoviews>=1.18
+distinctipy>=1.3
+tqdm>=4.65

--- a/PyMEOS_Examples/requirements.txt
+++ b/PyMEOS_Examples/requirements.txt
@@ -1,0 +1,5 @@
+pymeos>=1.3.0a1
+pandas>=2.0
+matplotlib>=3.7
+tqdm>=4.65
+contextily>=1.3

--- a/PyMEOS_Examples/requirements.txt
+++ b/PyMEOS_Examples/requirements.txt
@@ -1,4 +1,4 @@
-pymeos>=1.3.0a1
+pymeos>=1.4.0a1
 pandas>=2.0
 matplotlib>=3.7
 tqdm>=4.65


### PR DESCRIPTION
Pins both per-folder requirements.txt files to pymeos>=1.4.0a1 to track the MEOS 1.4 surface. Examples use the high-level PyMEOS Python API only (no direct pymeos_cffi imports), so no code changes accompany the version bump. Draft until PyMEOS 1.4 lands.